### PR TITLE
convert return images to tensor, to ensure broader compatibility

### DIFF
--- a/src/nodes/idm_vton.py
+++ b/src/nodes/idm_vton.py
@@ -118,5 +118,5 @@ class IDM_VTON:
                     
                     images = [transforms.ToTensor()(image) for image in images]
                     images = [image.permute(1,2,0) for image in images]
-                    
+                    images = torch.stack(images)
                     return (images, )


### PR DESCRIPTION
The current node version returns images as a list. This causes errors if we try to use the output image as input for another node. For example if we pipeline two IDM-VTON, using the output IMAGE of the first as human_img input of the second, we got the following error:

```
Error occurred when executing IDM-VTON:

'list' object has no attribute 'squeeze'
```
This was an example, but this happens also with other nodes that uses the IMAGE as input.
Just by converting the list in tensor fixes the problem.