### PR TITLE
Bug: Do not use symlinks for models in Linux, ends up in error model not found

### DIFF
--- a/install.py
+++ b/install.py
@@ -22,4 +22,4 @@ def ensure_package():
 
 if __name__ == "__main__":
     ensure_package()
-    snapshot_download(repo_id=HF_REPO_ID, local_dir=WEIGHTS_PATH)
+    snapshot_download(repo_id=HF_REPO_ID, local_dir=WEIGHTS_PATH, local_dir_use_symlinks=False)


### PR DESCRIPTION
The nodes uses symlinks for the models.

Getting errors while trying to find models, Add `local_dir_use_symlinks=False` in `snapshot_download(repo_id=HF_REPO_ID, local_dir=WEIGHTS_PATH, local_dir_use_symlinks=False)` fixes the issue for us. 

![image (3)](https://github.com/user-attachments/assets/d8834659-1e65-4a5a-9e53-c01fe87ff9d7)
